### PR TITLE
Various fixes and improvements:

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: true
-AllowShortCaseLabelsOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true

--- a/include/serialize/meta.hpp
+++ b/include/serialize/meta.hpp
@@ -147,7 +147,7 @@ struct IsIterableImpl<
     T,
     When<detail::Valid<decltype(
         // begin/end and operator !=
-        begin(std::declval<T&>()) != end(std::declval<T&>()),
+        static_cast<void>(begin(std::declval<T&>()) != end(std::declval<T&>())),
 
         // operator ++
         ++std::declval<decltype(begin(std::declval<T&>()))&>(),

--- a/include/serialize/type_name.hpp
+++ b/include/serialize/type_name.hpp
@@ -148,16 +148,23 @@ struct TypeNameImpl<int64_t> {
 // character
 
 template <>
-struct TypeNameImpl<unsigned char> {
+struct TypeNameImpl<char> {
     static constexpr std::string_view apply() noexcept {
-        return "uchar8";
+        return "char";
     }
 };
 
 template <>
-struct TypeNameImpl<char> {
+struct TypeNameImpl<uint8_t> {
     static constexpr std::string_view apply() noexcept {
-        return "char8";
+        return "uint8";
+    }
+};
+
+template <>
+struct TypeNameImpl<int8_t> {
+    static constexpr std::string_view apply() noexcept {
+        return "int8";
     }
 };
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 RUN apt-get -y update && apt-get -y install \
     libgl1-mesa-glx libglib2.0-0 libfontconfig1 libdbus-1-3 libxrender1 \
     bash-completion \
-    build-essential git cmake wget tar sudo \
+    build-essential git cmake wget tar sudo gdb \
     doxygen \
     lcov
 

--- a/test/type_name.cpp
+++ b/test/type_name.cpp
@@ -98,13 +98,14 @@ TEST_CASE("Check typeName", "[utilities]") {
     REQUIRE(typeName(boost::hana::type_c<float>) == "float");
     REQUIRE(typeName(boost::hana::type_c<double>) == "double");
     REQUIRE(typeName(boost::hana::type_c<wchar_t>) == "wchar");
-    REQUIRE(typeName(boost::hana::type_c<std::optional<char>>) == "optional char8");
+    REQUIRE(typeName(boost::hana::type_c<std::optional<char>>) == "optional char");
     REQUIRE(typeName(boost::hana::type_c<std::nullptr_t>) == "nullptr");
     REQUIRE(typeName(boost::hana::type_c<std::monostate>) == "null");
-    REQUIRE(typeName(boost::hana::type_c<std::variant<char, bool>>) == "one of [char8, boolean]");
+    REQUIRE(typeName(boost::hana::type_c<std::variant<char, bool>>) == "one of [char, boolean]");
     REQUIRE(typeName(boost::hana::type_c<bool>) == "boolean");
-    REQUIRE(typeName(boost::hana::type_c<char>) == "char8");
-    REQUIRE(typeName(boost::hana::type_c<unsigned char>) == "uchar8");
+    REQUIRE(typeName(boost::hana::type_c<char>) == "char");
+    REQUIRE(typeName(boost::hana::type_c<int8_t>) == "int8");
+    REQUIRE(typeName(boost::hana::type_c<uint8_t>) == "uint8");
     REQUIRE(typeName(boost::hana::type_c<uint16_t>) == "uint16");
     REQUIRE(typeName(boost::hana::type_c<int32_t>) == "int32");
     REQUIRE(typeName(boost::hana::type_c<uint32_t>) == "uint32");

--- a/test/variant_conversion.cpp
+++ b/test/variant_conversion.cpp
@@ -26,6 +26,8 @@
 
 #include <catch2/catch.hpp>
 
+#include <boost/hana/fuse.hpp>
+
 #include <map>
 #include <set>
 
@@ -84,48 +86,81 @@ struct E2Traits {
 } // namespace
 
 TEST_CASE("Check toVariant/fromVariant", "[variant_conversion]") {
-    REQUIRE(toVariant(Variant(1)) == Variant(1));
-    struct X {
-        static serialize::Variant toVariant(X const&) { return Variant(1); }
-    };
-    REQUIRE(toVariant(X()) == Variant(1));
-    boost::hana::for_each(Variant::Types::rebind_t<boost::hana::tuple>(), [](auto type) {
-        REQUIRE(toVariant(typename decltype(type)::type()) ==
-                Variant(typename decltype(type)::type()));
-    });
-    REQUIRE(toVariant(std::map<std::string, int>{{"1", 1}}) ==
-            Variant(VariantMap{{"1", Variant(1)}}));
-    REQUIRE(toVariant(std::pair(1, "1")) ==
-            Variant(VariantMap{{"first", Variant(1)}, {"second", Variant("1")}}));
-
-    REQUIRE(toVariant(E::e1) == Variant("e1"));
-    REQUIRE(fromVariant<E>(Variant("e2")) == E::e2);
-
-    using V = std::variant<int, std::string>;
-    REQUIRE(toVariant(V("a")) == Variant("a"));
-    REQUIRE(toVariant(V(1)) == Variant(1));
-
-    REQUIRE(fromVariant<V>(Variant(1)) == V(1));
-    REQUIRE(fromVariant<V>(Variant("a")) == V("a"));
-    REQUIRE_THROWS_AS(fromVariant<V>(Variant(1.2)) == V("a"), VariantBadType);
-    REQUIRE_THROWS_WITH(fromVariant<V>(Variant(1.5)) == V("a"), "'1.5' is not of type 'one of [int32, string]'");
-
-    REQUIRE(fromVariant<Test>(Variant()) == Test());
-    REQUIRE(toVariant(Test()) == Variant());
-
-    REQUIRE(Variant(1) == toVariant(Variant(1)));
-
-    REQUIRE(Variant("val1") == toVariant(E2::val1));
-
-    SECTION("vector") {
-        REQUIRE_THROWS_WITH(fromVariant<std::vector<E>>(Variant(VariantVec{Variant("e1"), Variant("e3")})), ".1: 'e3' is not of type 'E'");
+    SECTION("`toVariant`/`fromVariant` static member functions") {
+        REQUIRE(fromVariant<Test>(Variant()) == Test());
+        REQUIRE(toVariant(Test()) == Variant());
     }
 
-    SECTION("set") {
-        REQUIRE_THROWS_WITH(fromVariant<std::set<E>>(Variant(VariantVec{Variant("e1"), Variant("e3")})), ".1: 'e3' is not of type 'E'");
+    SECTION("Variant") {
+        REQUIRE(Variant(1) == toVariant(Variant(1)));
     }
 
-    SECTION("hana map") {
+    SECTION("enum class") {
+        REQUIRE(toVariant(E::e1) == Variant("e1"));
+        REQUIRE(fromVariant<E>(Variant("e2")) == E::e2);
+    }
+
+    SECTION("enum") {
+        REQUIRE(Variant("val1") == toVariant(E2::val1));
+    }
+
+    SECTION("std::map") {
+        REQUIRE(toVariant(std::map<std::string, int>{{"1", 1}})
+                == Variant(VariantMap{{"1", Variant(1)}}));
+    }
+
+    SECTION("std::pair") {
+        REQUIRE(toVariant(std::pair(1, "1"))
+                == Variant(VariantMap{{"first", Variant(1)}, {"second", Variant("1")}}));
+    }
+
+    SECTION("std::variant") {
+        using V = std::variant<int, std::string>;
+        REQUIRE(toVariant(V("a")) == Variant("a"));
+        REQUIRE(toVariant(V(1)) == Variant(1));
+
+        REQUIRE(fromVariant<V>(Variant(1)) == V(1));
+        REQUIRE(fromVariant<V>(Variant("a")) == V("a"));
+        REQUIRE_THROWS_AS(fromVariant<V>(Variant(1.2)) == V("a"), VariantBadType);
+        REQUIRE_THROWS_WITH(fromVariant<V>(Variant(1.5)) == V("a"),
+                            "'1.5' is not of type 'one of [int32, string]'");
+    }
+
+    SECTION("std::vector") {
+        REQUIRE_THROWS_WITH(fromVariant<std::vector<E>>(
+                                    Variant(VariantVec{Variant("e1"), Variant("e3")})),
+                            ".1: 'e3' is not of type 'E'");
+    }
+
+    SECTION("std::set") {
+        REQUIRE_THROWS_WITH(fromVariant<std::set<E>>(
+                                    Variant(VariantVec{Variant("e1"), Variant("e3")})),
+                            ".1: 'e3' is not of type 'E'");
+    }
+
+    SECTION("std::array") {
+        std::array<int, 2> const a{1, 2};
+
+        SECTION("ok") {
+            Variant const v(VariantVec{Variant{1}, Variant{2}});
+            REQUIRE(v == toVariant(a));
+            REQUIRE(fromVariant<std::array<int, 2>>(v) == a);
+        }
+
+        SECTION("size does not match") {
+            Variant const v(VariantVec{Variant{1}});
+            REQUIRE_THROWS_WITH((fromVariant<std::array<int, 2>>(v)),
+                                "expected size of the list is 2, actual 1");
+        }
+
+        SECTION("element bad type") {
+            Variant const v(VariantVec{Variant{"1"}, Variant(1)});
+            REQUIRE_THROWS_WITH((fromVariant<std::array<int, 2>>(v)),
+                                ".0: expected 'int32', actual 'string'");
+        }
+    }
+
+    SECTION("hana::map") {
         auto tmp = boost::hana::make_map(
             boost::hana::make_pair(BOOST_HANA_STRING("a"), E()),
             boost::hana::make_pair(BOOST_HANA_STRING("b"), E()));
@@ -133,11 +168,64 @@ TEST_CASE("Check toVariant/fromVariant", "[variant_conversion]") {
         REQUIRE_THROWS_WITH(fromVariant2(tmp, Variant(VariantMap{{"a", Variant("e1")}, {"b", Variant("e3")}})), ".b: 'e3' is not of type 'E'");
     }
 
-    SECTION("hana string") {
+    SECTION("hana::string") {
         using Str = decltype("str"_s);
         REQUIRE_NOTHROW(fromVariant<Str>(Variant("str")));
         REQUIRE_THROWS_WITH(fromVariant<Str>(Variant("strr")),
                             "'strr' is not of type 'str literal'");
         REQUIRE(toVariant("str"_s) == Variant("str"));
+    }
+
+    SECTION("hana::tuple") {
+        using namespace std::string_literals;
+        auto tuple = boost::hana::make_tuple(1, "2"s);
+
+        SECTION("ok") {
+            Variant const v(VariantVec{Variant{1}, Variant{"2"}});
+            REQUIRE(v == toVariant(tuple));
+            REQUIRE(boost::hana::equal(tuple, fromVariant<decltype(tuple)>(v)));
+        }
+
+        SECTION("size does not match") {
+            Variant const v(VariantVec{Variant{1}});
+            REQUIRE_THROWS_WITH((fromVariant<decltype(tuple)>(v)),
+                                "expected size of the tuple is 2, actual 1");
+        }
+
+        SECTION("element bad type") {
+            Variant const v(VariantVec{Variant{"1"}, Variant(2)});
+            REQUIRE_THROWS_WITH((fromVariant<decltype(tuple)>(v)),
+                                ".0: expected 'int32', actual 'string'");
+        }
+
+        REQUIRE(toVariant(tuple) == VariantVec{1, "2"});
+    }
+
+    SECTION("Variant supported types") {
+        SECTION("auto") {
+            boost::hana::for_each(
+                    Variant::Types::rebind_t<boost::hana::tuple>(), [](auto type) {
+                        REQUIRE(toVariant(typename decltype(type)::type())
+                                == Variant(typename decltype(type)::type()));
+                    });
+        }
+
+        SECTION("manual") {
+            auto const integrals = boost::hana::make_tuple(
+                    boost::hana::make_pair(Variant::NullType{}, Variant{}),
+                    boost::hana::make_pair(bool{true}, Variant{true}),
+                    boost::hana::make_pair(char{0}, Variant{char{0}}),
+                    boost::hana::make_pair(uint8_t{0}, Variant{uint8_t{0}}),
+                    boost::hana::make_pair(int8_t{0}, Variant{int8_t{0}}),
+                    boost::hana::make_pair(uint64_t{0}, Variant{uint64_t{0}}),
+                    boost::hana::make_pair(int64_t{0}, Variant{int64_t{0}}),
+                    boost::hana::make_pair(uint32_t{0}, Variant{uint32_t{0}}),
+                    boost::hana::make_pair(int32_t{0}, Variant{int32_t{0}}),
+                    boost::hana::make_pair(uint16_t{0}, Variant{uint16_t{0}}));
+            boost::hana::for_each(integrals, boost::hana::fuse([](auto rv, auto vv) {
+                                      REQUIRE(toVariant(rv) == vv);
+                                      REQUIRE(fromVariant<decltype(rv)>(vv) == rv);
+                                  }));
+        }
     }
 }


### PR DESCRIPTION
* fix compilation with newer compilers;
* add int8_t;
* add conversion to `NullType`;
* implicit conversions to `Variant`;
* fix copy and move assignments of `Variant`;
* fix `Variant` 'throws' documentation;
* support `hana::string`, `hana:tuple`, `std::array` in
* `toVariant`/`fromVariant`;
* implement implicit safe implicit conversion from double to integral types;
* implement variant equality comparision considering implicit arithmetic conversions: `equal(Variant, Variant)`;