### PR TITLE
Fix some clang-tidy warnings

### DIFF
--- a/include/yenxo/variant.hpp
+++ b/include/yenxo/variant.hpp
@@ -122,7 +122,7 @@ public:
 
     // move
     Variant(Variant&& rhs) noexcept;
-    Variant& operator=(Variant&& rhs);
+    Variant& operator=(Variant&& rhs) noexcept;
 
     /// Get `NullType`
     /// \throw VariantBadType
@@ -297,7 +297,7 @@ public:
     /// Check if two `Variant`s are equal
     ///
     /// Unlike `operator==` this function performs conversion of arithmetic types.
-    friend bool equal(Variant const& lhs, Variant const& rhs) noexcept;
+    friend bool equal(Variant const& lhs, Variant const& rhs);
 
     /// \ingroup group-json
     /// @{

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -186,7 +186,7 @@ Variant::Variant(Variant&& rhs) noexcept
     rhs.value_.null_ = {};
 }
 
-Variant& Variant::operator=(Variant&& rhs) {
+Variant& Variant::operator=(Variant&& rhs) noexcept {
     this->~Variant();
     new (this) Variant(std::move(rhs));
     return *this;
@@ -512,7 +512,7 @@ decltype(auto) getHelper(Variant::TypeTag tag, U value_) {
 } // namespace
 
 #define GET_HELPER(T, tag, value, x)                                                     \
-    if (tag == TypeTag::null) {                                                          \
+    if ((tag) == TypeTag::null) {                                                        \
         return x;                                                                        \
     } else {                                                                             \
         return getHelper<T>(tag, value);                                                 \
@@ -873,7 +873,7 @@ bool equalArithmetic(T lhs, Variant::TypeTag tag, U const& rhs) {
 
 } // namespace
 
-bool equal(Variant const& lhs, Variant const& rhs) noexcept {
+bool equal(Variant const& lhs, Variant const& rhs) {
     using TypeTag = Variant::TypeTag;
     using Map = Variant::Map;
 


### PR DESCRIPTION
- `yenxo::Variant::operator=(Variant&&)` is marked as `noexcept`
- modifier `noexcept` is removed in `bool equal(Variant const& lhs, Variant const& rhs)` because it can throw
- macro attribute is wrapped with brackets