### PR TITLE
Plus as space

### DIFF
--- a/src/query_string.cpp
+++ b/src/query_string.cpp
@@ -116,9 +116,7 @@ public:
                     - (open_bracket | close_bracket);
 
         sub_delims %= char_('!') | char_('$') | char_('\'') | char_('(') | char_(')')
-                    | char_('*') | char_('+') | char_(',') | char_(';');
-
-        plus_as_space %= lit('+')[_val = ' '];
+                    | char_('*') | char_(',') | char_(';') | lit('+')[_val = ' '];
 
         unreserved %= alnum | char_('-') | char_(".") | char_("_") | char_("~");
         pchar %= unreserved | pct_encoded | sub_delims | char_(':') | char_('@');
@@ -126,7 +124,7 @@ public:
         index %= omit[open_bracket] >> ulong_long > omit[close_bracket];
         property %= omit[open_bracket] >> +pchar > omit[close_bracket];
         empty_index = open_bracket > close_bracket;
-        name %= +(plus_as_space | pchar);
+        name %= pchar;
 
         key = name[phx::bind(&Grammar::paramName, this, _1)]
             > *(index[phx::bind(&Grammar::indexOp, this, _1)]
@@ -134,7 +132,7 @@ public:
             > -empty_index[phx::bind(&Grammar::emptyIndexOp, this)];
 
         empty_value = &lit('&') | eoi;
-        value %= +(plus_as_space | pchar | open_bracket | close_bracket);
+        value %= +(pchar | open_bracket | close_bracket);
 
         empty_parameter = &lit('&') | eoi;
         parameter = key > lit('=') > (value[phx::bind(&Grammar::val, this, _1)]
@@ -297,7 +295,6 @@ private:
     qi::rule<Iterator, char()> sub_delims;
     qi::rule<Iterator, char()> open_bracket;
     qi::rule<Iterator, char()> close_bracket;
-    qi::rule<Iterator, char()> plus_as_space;
     qi::rule<Iterator, std::string()> property;
     qi::rule<Iterator, uint16_t()> index;
     qi::rule<Iterator> empty_index;

--- a/src/query_string.cpp
+++ b/src/query_string.cpp
@@ -124,7 +124,7 @@ public:
         index %= omit[open_bracket] >> ulong_long > omit[close_bracket];
         property %= omit[open_bracket] >> +pchar > omit[close_bracket];
         empty_index = open_bracket > close_bracket;
-        name %= pchar;
+        name %= +pchar;
 
         key = name[phx::bind(&Grammar::paramName, this, _1)]
             > *(index[phx::bind(&Grammar::indexOp, this, _1)]

--- a/test/query_string.cpp
+++ b/test/query_string.cpp
@@ -294,7 +294,7 @@ TEST_CASE("Check query_string", "[query]") {
         REQUIRE(query_string("a+b=1&a+b=2") == R"({"a b": ["1", "2"]})"_j);
     }
 
-    SECTION("parsing precend encoded plus as plus") {
+    SECTION("parsing perecent encoded plus as plus") {
         REQUIRE(query_string("a%2bb=1") == R"({"a+b": "1"})"_j);
     }
 }

--- a/test/query_string.cpp
+++ b/test/query_string.cpp
@@ -288,4 +288,13 @@ TEST_CASE("Check query_string", "[query]") {
         REQUIRE_THROWS_WITH(query_string("a[x]=1&a[]=2"),
                             R"(mixed types for a: vec and map)");
     }
+
+    SECTION("parsing plus as space") {
+        REQUIRE(query_string("a+b=1") == R"({"a b": "1"})"_j);
+        REQUIRE(query_string("a+b=1&a+b=2") == R"({"a b": ["1", "2"]})"_j);
+    }
+
+    SECTION("parsing precend encoded plus as plus") {
+        REQUIRE(query_string("a%2bb=1") == R"({"a+b": "1"})"_j);
+    }
 }


### PR DESCRIPTION
According to this: https://url.spec.whatwg.org/#concept-urlencoded-parser  , all pluses should be converted to spaces in query part of the URI/URL.