### PR TITLE
Add enum ToVariant extension point to specialization

### DIFF
--- a/include/yenxo/variant_conversion.hpp
+++ b/include/yenxo/variant_conversion.hpp
@@ -290,12 +290,12 @@ struct ToVariantImpl<T, When<isCollectionType(boost::hana::type_c<T>)>> {
     }
 };
 template <typename T>
-struct HasCustomToVariant : std::false_type {};
+struct DisableDefaultToVariant : std::false_type {};
 // Specialization for types with specialized EnumTraits
 template <class T>
 struct ToVariantImpl<
         T,
-        When<isReflectiveEnum(boost::hana::type_c<T>) && !HasCustomToVariant<T>::value>> {
+        When<isReflectiveEnum(boost::hana::type_c<T>) && !DisableDefaultToVariant<T>::value>> {
     static Variant apply(T e) {
         return Variant(EnumTraits<T>::toString(e));
     }
@@ -811,6 +811,7 @@ inline constexpr auto toVariantConvertible = [](auto type) {
            || isMapType(type)
            || isCollectionType(type)
            || isReflectiveEnum(type)
+           || DisableDefaultToVariant<typename decltype(type)::type>::value
            || isPair(type)
            || isTuple(type)
 #if YENXO_ENABLE_TYPE_SAFE

--- a/include/yenxo/variant_conversion.hpp
+++ b/include/yenxo/variant_conversion.hpp
@@ -289,10 +289,13 @@ struct ToVariantImpl<T, When<isCollectionType(boost::hana::type_c<T>)>> {
         return Variant(ret);
     }
 };
-
+template <typename T>
+struct HasCustomToVariant : std::false_type {};
 // Specialization for types with specialized EnumTraits
 template <class T>
-struct ToVariantImpl<T, When<isReflectiveEnum(boost::hana::type_c<T>)>> {
+struct ToVariantImpl<
+        T,
+        When<isReflectiveEnum(boost::hana::type_c<T>) && !HasCustomToVariant<T>::value>> {
     static Variant apply(T e) {
         return Variant(EnumTraits<T>::toString(e));
     }

--- a/test/variant_conversion.cpp
+++ b/test/variant_conversion.cpp
@@ -150,15 +150,14 @@ constexpr bool HasCustomCall = HasCustomCallImpl<T>::value;
 
 } // namespace
 
-template <typename T>
-struct yenxo::DisableDefaultToVariant<T, std::enable_if_t<HasCustomCall<T>>>
-    : std::true_type {};
+template <>
+struct yenxo::DisableDefaultToVariant<ConceptE> : std::true_type {};
 
-template <typename T>
-struct yenxo::ToVariantImpl<T, yenxo::When<HasCustomCall<T>>> {
-    static Variant apply(T e) {
-        return Variant(std::string(EnumTraits<T>::custom_call()) + "_"
-                       + EnumTraits<T>::toString(e));
+template <>
+struct yenxo::ToVariantImpl<ConceptE, void> {
+    static Variant apply(ConceptE e) {
+        return Variant(std::string(EnumTraits<ConceptE>::custom_call()) + "_"
+                       + EnumTraits<ConceptE>::toString(e));
     }
 };
 

--- a/test/variant_conversion.cpp
+++ b/test/variant_conversion.cpp
@@ -97,59 +97,59 @@ struct E2Traits {
 
 [[maybe_unused]] E2Traits traits(E2) {
     return {};
+};
+enum class PlainE { a, b };
+enum class ConceptE { x, y };
 
-    enum class PlainE { a, b };
-    enum class ConceptE { x, y };
-
-    struct PlainETraits {
-        using Enum = PlainE;
-        static char const* toString(Enum x) {
-            switch (x) {
-            case Enum::a:
-                return "a";
-            case Enum::b:
-                return "b";
-            }
-            throw 1;
+struct PlainETraits {
+    using Enum = PlainE;
+    static char const* toString(Enum x) {
+        switch (x) {
+        case Enum::a:
+            return "a";
+        case Enum::b:
+            return "b";
         }
-    };
-
-    struct ConceptETraits {
-        using Enum = ConceptE;
-        static char const* toString(Enum x) {
-            switch (x) {
-            case Enum::x:
-                return "x";
-            case Enum::y:
-                return "y";
-            }
-            throw 1;
-        }
-        static std::string_view custom_call() {
-            return "custom";
-        }
-    };
-
-    [[maybe_unused]] PlainETraits traits(PlainE) {
-        return {};
+        throw 1;
     }
-    [[maybe_unused]] ConceptETraits traits(ConceptE) {
-        return {};
-    }
+};
 
-    template <typename T>
-    concept HasCustomCall = requires { EnumTraits<T>::custom_call(); };
-
-    template <HasCustomCall T>
-    struct yenxo::DisableDefaultToVariant<T> : std::true_type {};
-
-    template <HasCustomCall T>
-    struct yenxo::ToVariantImpl<T, yenxo::When<true>> {
-        static Variant apply(T e) {
-            return Variant(std::string(EnumTraits<T>::custom_call()) + "_"
-                           + EnumTraits<T>::toString(e));
+struct ConceptETraits {
+    using Enum = ConceptE;
+    static char const* toString(Enum x) {
+        switch (x) {
+        case Enum::x:
+            return "x";
+        case Enum::y:
+            return "y";
         }
-    };
+        throw 1;
+    }
+    static std::string_view custom_call() {
+        return "custom";
+    }
+};
+
+[[maybe_unused]] PlainETraits traits(PlainE) {
+    return {};
+}
+[[maybe_unused]] ConceptETraits traits(ConceptE) {
+    return {};
+}
+
+template <typename T>
+concept HasCustomCall = requires { EnumTraits<T>::custom_call(); };
+
+template <HasCustomCall T>
+struct yenxo::DisableDefaultToVariant<T> : std::true_type {};
+
+template <HasCustomCall T>
+struct yenxo::ToVariantImpl<T, yenxo::When<true>> {
+    static Variant apply(T e) {
+        return Variant(std::string(EnumTraits<T>::custom_call()) + "_"
+                       + EnumTraits<T>::toString(e));
+    }
+};
 
 } // namespace
 

--- a/test/variant_conversion.cpp
+++ b/test/variant_conversion.cpp
@@ -97,7 +97,8 @@ struct E2Traits {
 
 [[maybe_unused]] E2Traits traits(E2) {
     return {};
-};
+}
+
 enum class PlainE { a, b };
 enum class ConceptE { x, y };
 
@@ -137,21 +138,31 @@ struct ConceptETraits {
     return {};
 }
 
+template <typename T, typename = void>
+struct HasCustomCallImpl : std::false_type {};
+
 template <typename T>
-concept HasCustomCall = requires { EnumTraits<T>::custom_call(); };
+struct HasCustomCallImpl<T, std::void_t<decltype(EnumTraits<T>::custom_call())>>
+    : std::true_type {};
 
-template <HasCustomCall T>
-struct yenxo::DisableDefaultToVariant<T> : std::true_type {};
+template <typename T>
+constexpr bool HasCustomCall = HasCustomCallImpl<T>::value;
 
-template <HasCustomCall T>
-struct yenxo::ToVariantImpl<T, yenxo::When<true>> {
+} // namespace
+
+template <typename T>
+struct yenxo::DisableDefaultToVariant<T, std::enable_if_t<HasCustomCall<T>>>
+    : std::true_type {};
+
+template <typename T>
+struct yenxo::ToVariantImpl<T, yenxo::When<HasCustomCall<T>>> {
     static Variant apply(T e) {
         return Variant(std::string(EnumTraits<T>::custom_call()) + "_"
                        + EnumTraits<T>::toString(e));
     }
 };
 
-} // namespace
+namespace {
 
 TEST_CASE("Check toVariant/fromVariant", "[variant_conversion]") {
     SECTION("`toVariant`/`fromVariant` static member functions") {
@@ -310,6 +321,7 @@ TEST_CASE("Check toVariant/fromVariant", "[variant_conversion]") {
                                   }));
         }
     }
+
     SECTION("plain reflective enum uses default path") {
         REQUIRE(toVariant(PlainE::a) == Variant("a"));
     }
@@ -318,8 +330,6 @@ TEST_CASE("Check toVariant/fromVariant", "[variant_conversion]") {
         REQUIRE(toVariant(ConceptE::x) == Variant("custom_x"));
     }
 }
-
-namespace {
 
 struct SimpleProperty {
     YENXO_FROM_VARIANT(SimpleProperty)
@@ -335,6 +345,7 @@ struct SpecialSymbol2 {
     YENXO_FROM_VARIANT(SpecialSymbol2)
     YENXO_DEFINE_STRUCT(SpecialSymbol2, (int, x, Name("~x/y/~")));
 };
+
 } // namespace
 
 TEST_CASE("Check VariantErr::path()", "[exception]") {

--- a/test/variant_conversion.cpp
+++ b/test/variant_conversion.cpp
@@ -97,7 +97,59 @@ struct E2Traits {
 
 [[maybe_unused]] E2Traits traits(E2) {
     return {};
-}
+
+    enum class PlainE { a, b };
+    enum class ConceptE { x, y };
+
+    struct PlainETraits {
+        using Enum = PlainE;
+        static char const* toString(Enum x) {
+            switch (x) {
+            case Enum::a:
+                return "a";
+            case Enum::b:
+                return "b";
+            }
+            throw 1;
+        }
+    };
+
+    struct ConceptETraits {
+        using Enum = ConceptE;
+        static char const* toString(Enum x) {
+            switch (x) {
+            case Enum::x:
+                return "x";
+            case Enum::y:
+                return "y";
+            }
+            throw 1;
+        }
+        static std::string_view custom_call() {
+            return "custom";
+        }
+    };
+
+    [[maybe_unused]] PlainETraits traits(PlainE) {
+        return {};
+    }
+    [[maybe_unused]] ConceptETraits traits(ConceptE) {
+        return {};
+    }
+
+    template <typename T>
+    concept HasCustomCall = requires { EnumTraits<T>::custom_call(); };
+
+    template <HasCustomCall T>
+    struct yenxo::DisableDefaultToVariant<T> : std::true_type {};
+
+    template <HasCustomCall T>
+    struct yenxo::ToVariantImpl<T, yenxo::When<true>> {
+        static Variant apply(T e) {
+            return Variant(std::string(EnumTraits<T>::custom_call()) + "_"
+                           + EnumTraits<T>::toString(e));
+        }
+    };
 
 } // namespace
 
@@ -258,6 +310,13 @@ TEST_CASE("Check toVariant/fromVariant", "[variant_conversion]") {
                                   }));
         }
     }
+    SECTION("plain reflective enum uses default path") {
+        REQUIRE(toVariant(PlainE::a) == Variant("a"));
+    }
+
+    SECTION("concept-matched enum uses custom path") {
+        REQUIRE(toVariant(ConceptE::x) == Variant("custom_x"));
+    }
 }
 
 namespace {
@@ -274,7 +333,9 @@ struct SpecialSymbol1 {
 
 struct SpecialSymbol2 {
     YENXO_FROM_VARIANT(SpecialSymbol2)
-    YENXO_DEFINE_STRUCT(SpecialSymbol2, (int, x, Name("~x/y/~"))); };  } // namespace
+    YENXO_DEFINE_STRUCT(SpecialSymbol2, (int, x, Name("~x/y/~")));
+};
+} // namespace
 
 TEST_CASE("Check VariantErr::path()", "[exception]") {
     REQUIRE_THROWS_MATCHES(fromVariant<SimpleProperty>(VariantMap{{"x", "1"}}),
@@ -293,3 +354,6 @@ static_assert(toVariantConvertible(boost::hana::type_c<int>));
 static_assert(
         toVariantConvertible(boost::hana::type_c<std::unordered_map<std::string, int>>));
 static_assert(toVariantConvertible(boost::hana::type_c<E>));
+static_assert(!HasCustomCall<PlainE>);
+static_assert(HasCustomCall<ConceptE>);
+static_assert(toVariantConvertible(boost::hana::type_c<ConceptE>));


### PR DESCRIPTION
ToVariant for enums spec was too broad, forbidding further non-explicit specialization. Added extension point.